### PR TITLE
implement skeleton for `meetings`, `schedules` module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ lerna-debug.log*
 !.vscode/extensions.json
 
 *.env
+*.eslintignore

--- a/src/dto/schedule.dto.interface.ts
+++ b/src/dto/schedule.dto.interface.ts
@@ -1,0 +1,6 @@
+import { MeetingDate } from "src/entity/meetingDate.entity";
+
+export interface Schedule {
+    nickname: string,
+    selected_items: MeetingDate[]
+}

--- a/src/meetings/meetings.controller.ts
+++ b/src/meetings/meetings.controller.ts
@@ -1,4 +1,12 @@
-import { Controller, Get } from '@nestjs/common';
+import {
+  Controller,
+  Delete,
+  Get,
+  Post,
+  Patch,
+  Param,
+  Body,
+} from '@nestjs/common';
 import { MeetingsService } from './meetings.service';
 
 @Controller('meetings')
@@ -6,7 +14,33 @@ export class MeetingsController {
   constructor(private readonly meetingsService: MeetingsService) {}
 
   @Get()
-  getHelloWorld(): string {
-    return this.meetingsService.getHelloWorld();
+  getMeetings() {
+    return this.meetingsService.getMeetings();
+  }
+
+  @Delete('/:id')
+  deleteMeetingById(@Param('id') meetingId: number) {
+    const success = this.meetingsService.deleteMeetingById(meetingId);
+    return { success };
+  }
+
+  @Patch('/:id/hiding')
+  patchMeetingById(
+    @Param('id') meetingId: number,
+    @Body('list_visible') listVisible: number,
+  ) {
+    const success = this.meetingsService.patchMeetingById(meetingId, listVisible);
+    return {success};
+  }
+
+  @Post()
+  createMeeting() {
+    const success = this.meetingsService.createMeeting();
+    return {success};
+  }
+
+  @Get('/:id')
+  getMeetingById(@Param('id') meetingId: number) {
+    return this.meetingsService.getMeetingById(meetingId);
   }
 }

--- a/src/meetings/meetings.service.ts
+++ b/src/meetings/meetings.service.ts
@@ -1,8 +1,25 @@
 import { Injectable } from '@nestjs/common';
+import { Meeting } from 'src/entity/meeting.entity';
 
 @Injectable()
 export class MeetingsService {
-  getHelloWorld(): string {
-    return 'Hello World!!';
+  getMeetings(): Meeting[] {
+    return [];
+  }
+
+  deleteMeetingById(meetingId: number): boolean {
+    return false;
+  }
+
+  patchMeetingById(meetingId: number, listVisible: number): boolean {
+    return false;
+  }
+
+  createMeeting(): boolean {
+    return false;
+  }
+
+  getMeetingById(meetingId: number): Meeting {
+    return;
   }
 }

--- a/src/meetings/schedule/meetings.schedule.controller.ts
+++ b/src/meetings/schedule/meetings.schedule.controller.ts
@@ -1,9 +1,38 @@
-import { Controller, Get } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
 import { MeetingsScheduleService } from './meetings.schedule.service';
+import { Schedule } from 'src/dto/schedule.dto.interface';
 
 @Controller('meetings/:id/schedule')
 export class MeetingsScheduleController {
   constructor(
     private readonly MeetingsScheduleService: MeetingsScheduleService,
   ) {}
+
+  @Post()
+  createSchedules(@Param('id') meetingId: number) {
+    const success = this.MeetingsScheduleService.createSchedules(meetingId);
+    return { success };
+  }
+
+  @Get()
+  getPersonalSchedules(@Param('id') meetingId: number) {
+    return this.MeetingsScheduleService.getPersonalSchedules(meetingId);
+  }
+
+  @Put()
+  updateSchedules(
+    @Param('id') meetingId: number,
+    @Body() newSchedule: Schedule,
+  ) {
+    const success = this.MeetingsScheduleService.updateSchedules(
+      meetingId,
+      newSchedule,
+    );
+    return { success };
+  }
+
+  @Get('/all')
+  getAllSchedules(@Param('id') meetingId: number) {
+    return this.MeetingsScheduleService.getAllSchedules(meetingId);
+  }
 }

--- a/src/meetings/schedule/meetings.schedule.service.ts
+++ b/src/meetings/schedule/meetings.schedule.service.ts
@@ -1,4 +1,21 @@
 import { Injectable } from '@nestjs/common';
+import { Schedule } from 'src/dto/schedule.dto.interface';
 
 @Injectable()
-export class MeetingsScheduleService {}
+export class MeetingsScheduleService {
+  createSchedules(meetingId: number): boolean {
+    return false;
+  }
+
+  getPersonalSchedules(meetingId: number): Schedule {
+    return;
+  }
+
+  updateSchedules(meetingId: number, newSchedule: Schedule): boolean {
+    return false;
+  }
+
+  getAllSchedules(meetingId: number): Schedule[] {
+    return [];
+  }
+}


### PR DESCRIPTION
- closes #7 
- `meetings`, `schedules` module의 service와 controller skeleton을 완성하였습니다.
- 추가적으로, schedules 통신시 필요한 것 같아서 dto interface를 추가하였습니다.