### PR TITLE
implement http exception filter for each module

### DIFF
--- a/src/http-exception.filter.ts
+++ b/src/http-exception.filter.ts
@@ -1,0 +1,22 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+@Catch(HttpException)
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+    const status = exception.getStatus();
+    const errMsg = exception.message;
+
+    response.status(status).json({
+      message: errMsg,
+    });
+  }
+}

--- a/src/meetings/meetings.module.ts
+++ b/src/meetings/meetings.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
 import { MeetingsService } from './meetings.service';
 import { MeetingsController } from './meetings.controller';
+import { APP_FILTER } from '@nestjs/core';
+import { HttpExceptionFilter } from 'src/http-exception.filter';
 
 @Module({
   controllers: [MeetingsController],
-  providers: [MeetingsService],
+  providers: [
+    MeetingsService,
+    { provide: APP_FILTER, useClass: HttpExceptionFilter },
+  ],
 })
 export class MeetingsModule {}


### PR DESCRIPTION
- closes #11 
- 참고: [공식 문서 링크](https://docs.nestjs.com/exception-filters)
- 각 모듈별로 http exception을 catch할 수 있는 exception filter입니다.
- 모듈 적용 예시와 함께 올려두었으니 diff 참고해주세요:)

서비스에서 Http Exception을 throw만 하면 됩니다. filter를 적용한 모듈이라면 filter에서 http exception은 catch 해줍니다.
단, 다른 종류의 exception은 잡아주지 않으므로 따로 처리해야 합니다.