### PR TITLE
`meetings` 모듈 api 구현

### DIFF
--- a/src/entity/meeting.entity.ts
+++ b/src/entity/meeting.entity.ts
@@ -9,14 +9,10 @@ import {
   OneToOne,
 } from 'typeorm';
 
-import {
-  Timezone,
-} from './timezone.entity.js';
-
-import { type } from 'os';
+import { Timezone } from './timezone.entity.js';
 import { MeetingMember } from './meetingMember.entity';
 import { SelectTimetable } from './selectTimetable.entity';
-import { MeetingDate } from './meetingDate.entity'
+import { MeetingDate } from './meetingDate.entity';
 import { Vote } from './vote.entity.js';
 import { Member } from './member.entity.js';
 
@@ -24,18 +20,18 @@ import { Member } from './member.entity.js';
 export class Meeting extends BaseEntity {
   @PrimaryGeneratedColumn()
   id: number;
-  
+
   @Column({ name: 'member_id' })
   member_id: number;
 
-  @ManyToOne(type=>Member, member =>member.meetings)
+  @ManyToOne((type) => Member, (member) => member.meetings)
   @JoinColumn({ name: 'member_id', referencedColumnName: 'id' })
   member: Member;
 
   @Column({ name: 'timezone_id' })
   timezone_id: number;
 
-  @ManyToOne(type=>Timezone, timezone =>timezone.meetings)
+  @ManyToOne((type) => Timezone, (timezone) => timezone.meetings)
   @JoinColumn({ name: 'timezone_id', referencedColumnName: 'id' })
   timezone: Timezone;
 
@@ -44,21 +40,27 @@ export class Meeting extends BaseEntity {
   })
   name: string;
 
-  @Column({type:'time'})
+  @Column({ type: 'time' })
   start_time: string;
 
-  @Column({type: 'time'})
+  @Column({ type: 'time' })
   end_time: string;
 
-  @OneToMany(type => MeetingMember, meeting_member => meeting_member.meeting)
+  @OneToMany(
+    (type) => MeetingMember,
+    (meeting_member) => meeting_member.meeting,
+  )
   meeting_members: MeetingMember[];
 
-  @OneToMany(type => MeetingDate, meeting_date => meeting_date.meeting)
+  @OneToMany((type) => MeetingDate, (meeting_date) => meeting_date.meeting)
   meeting_dates: MeetingDate[];
 
-  @OneToMany(type => SelectTimetable, select_timetable => select_timetable.meeting)
+  @OneToMany(
+    (type) => SelectTimetable,
+    (select_timetable) => select_timetable.meeting,
+  )
   select_timetables: SelectTimetable[];
 
-  @OneToOne(type =>Vote, vote => vote.meeting, { cascade: true })
+  @OneToOne((type) => Vote, (vote) => vote.meeting, { cascade: true })
   vote: Vote;
 }

--- a/src/meetings/dto/availableDate.dto.ts
+++ b/src/meetings/dto/availableDate.dto.ts
@@ -1,0 +1,6 @@
+import { IsString } from "class-validator";
+
+export class AvailableDate {
+    @IsString()
+    date: string;
+}

--- a/src/meetings/dto/meeting.dto.ts
+++ b/src/meetings/dto/meeting.dto.ts
@@ -1,7 +1,19 @@
-export class MeetingDto{
-    name: string;
-    available_date: string[];
-    start_time: string;
-    end_time: string;
-    timezone_id: number;
+import { IsArray, IsNumber, IsString } from 'class-validator';
+import { AvailableDate } from './availableDate.dto';
+
+export class MeetingDto {
+  @IsString({ message: '미팅 이름을 설정해주세요.' })
+  name: string;
+
+  @IsArray({ message: '선택지를 하나 이상 추가하세요.' })
+  available_dates: AvailableDate[];
+  
+  @IsString()
+  start_time: string;
+
+  @IsString()
+  end_time: string;
+
+  @IsNumber()
+  timezone_id: number;
 }

--- a/src/meetings/dto/meeting.dto.ts
+++ b/src/meetings/dto/meeting.dto.ts
@@ -1,0 +1,8 @@
+export class MeetingDto{
+    name: string;
+    available_date: string[];
+    date: string;
+    start_time: string;
+    end_time: string;
+    timezone_id: number;
+}

--- a/src/meetings/dto/meeting.dto.ts
+++ b/src/meetings/dto/meeting.dto.ts
@@ -1,7 +1,6 @@
 export class MeetingDto{
     name: string;
     available_date: string[];
-    date: string;
     start_time: string;
     end_time: string;
     timezone_id: number;

--- a/src/meetings/meetings.controller.ts
+++ b/src/meetings/meetings.controller.ts
@@ -24,18 +24,18 @@ export class MeetingsController {
   }
 
   @Patch('/:id/hiding')
-  patchMeetingById(
+  hideMeetingById(
     @Param('id') meetingId: number,
     @Body('list_visible') listVisible: number,
   ) {
-    const success = this.meetingsService.patchMeetingById(meetingId, listVisible);
-    return {success};
+    const memberId = 1; // TODO: member Id를 request에서 파싱
+    return this.meetingsService.hideMeetingById(meetingId, memberId, listVisible);
   }
 
   @Post()
   createMeeting() {
     const success = this.meetingsService.createMeeting();
-    return {success};
+    return { success };
   }
 
   @Get('/:id')

--- a/src/meetings/meetings.controller.ts
+++ b/src/meetings/meetings.controller.ts
@@ -47,4 +47,14 @@ export class MeetingsController {
   getMeetingById(@Param('id') meetingId: number) {
     return this.meetingsService.getMeetingById(meetingId);
   }
+
+  @Post('/test/member')
+  createMember(@Body('email') email: string) {
+    return this.meetingsService.insertMember(email);
+  }
+
+  @Post('/test/timezone')
+  createTimezone(@Body('name') name: string) {
+    return this.meetingsService.insertTimezone(name);
+  }
 }

--- a/src/meetings/meetings.controller.ts
+++ b/src/meetings/meetings.controller.ts
@@ -30,13 +30,17 @@ export class MeetingsController {
     @Body('list_visible') listVisible: number,
   ) {
     const memberId = 1; // TODO: member id를 request에서 파싱
-    return this.meetingsService.hideMeetingById(meetingId, memberId, listVisible);
+    return this.meetingsService.hideMeetingById(
+      memberId,
+      meetingId,
+      listVisible,
+    );
   }
 
   @Post()
-  createMeeting(@Body() meeting: MeetingDto) {
-    const managerId = 0; // TODO: member id를 request에서 파싱
-    return this.meetingsService.createMeeting(meeting, managerId);
+  createMeeting(@Body() meetingDto: MeetingDto) {
+    const managerId = 1; // TODO: member id를 request에서 파싱
+    return this.meetingsService.createMeeting(meetingDto, managerId);
   }
 
   @Get('/:id')

--- a/src/meetings/meetings.controller.ts
+++ b/src/meetings/meetings.controller.ts
@@ -8,6 +8,7 @@ import {
   Body,
 } from '@nestjs/common';
 import { MeetingsService } from './meetings.service';
+import { MeetingDto } from './dto/meeting.dto';
 
 @Controller('meetings')
 export class MeetingsController {
@@ -28,14 +29,14 @@ export class MeetingsController {
     @Param('id') meetingId: number,
     @Body('list_visible') listVisible: number,
   ) {
-    const memberId = 1; // TODO: member Id를 request에서 파싱
+    const memberId = 1; // TODO: member id를 request에서 파싱
     return this.meetingsService.hideMeetingById(meetingId, memberId, listVisible);
   }
 
   @Post()
-  createMeeting() {
-    const success = this.meetingsService.createMeeting();
-    return { success };
+  createMeeting(@Body() meeting: MeetingDto) {
+    const managerId = 0; // TODO: member id를 request에서 파싱
+    return this.meetingsService.createMeeting(meeting, managerId);
   }
 
   @Get('/:id')

--- a/src/meetings/meetings.controller.ts
+++ b/src/meetings/meetings.controller.ts
@@ -20,8 +20,7 @@ export class MeetingsController {
 
   @Delete('/:id')
   deleteMeetingById(@Param('id') meetingId: number) {
-    const success = this.meetingsService.deleteMeetingById(meetingId);
-    return { success };
+    return this.meetingsService.deleteMeetingById(meetingId);
   }
 
   @Patch('/:id/hiding')

--- a/src/meetings/meetings.module.ts
+++ b/src/meetings/meetings.module.ts
@@ -3,8 +3,11 @@ import { MeetingsService } from './meetings.service';
 import { MeetingsController } from './meetings.controller';
 import { APP_FILTER } from '@nestjs/core';
 import { HttpExceptionFilter } from 'src/common/exception-filter/http-exception.filter';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Meeting } from 'src/entity/meeting.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Meeting])],
   controllers: [MeetingsController],
   providers: [
     MeetingsService,

--- a/src/meetings/meetings.module.ts
+++ b/src/meetings/meetings.module.ts
@@ -5,9 +5,21 @@ import { APP_FILTER } from '@nestjs/core';
 import { HttpExceptionFilter } from 'src/common/exception-filter/http-exception.filter';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Meeting } from 'src/entity/meeting.entity';
+import { MeetingMember } from 'src/entity/meetingMember.entity';
+import { MeetingDate } from 'src/entity/meetingDate.entity';
+import { Member } from 'src/entity/member.entity';
+import { Timezone } from 'src/entity/timezone.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Meeting])],
+  imports: [
+    TypeOrmModule.forFeature([
+      Meeting,
+      MeetingMember,
+      MeetingDate,
+      Member,
+      Timezone,
+    ]),
+  ],
   controllers: [MeetingsController],
   providers: [
     MeetingsService,

--- a/src/meetings/meetings.service.ts
+++ b/src/meetings/meetings.service.ts
@@ -97,4 +97,26 @@ export class MeetingsService {
 
     return meeting;
   }
+
+  generateRandomString(length: number): string {
+    let result = '';
+    let characters =
+      'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    let charactersLength = characters.length;
+    for (let i = 0; i < length; i++) {
+      result += characters.charAt(Math.floor(Math.random() * charactersLength));
+    }
+    return result;
+  }
+
+  async insertMember(email: string) {
+    return await this.members.insert({
+      token: this.generateRandomString(10),
+      email,
+    });
+  }
+
+  async insertTimezone(name: string) {
+    return await this.timezones.insert({ name });
+  }
 }

--- a/src/meetings/meetings.service.ts
+++ b/src/meetings/meetings.service.ts
@@ -1,3 +1,4 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Meeting } from 'src/entity/meeting.entity';
 import { Repository } from 'typeorm';
@@ -8,6 +9,9 @@ export class MeetingsService {
     @InjectRepository(Meeting)
     private meetings: Repository<Meeting>,
   ) {}
+
+  async getMeetings(): Promise<Meeting[]> {
+    return await this.meetings.find();
   }
 
   deleteMeetingById(meetingId: number): boolean {

--- a/src/meetings/meetings.service.ts
+++ b/src/meetings/meetings.service.ts
@@ -4,6 +4,10 @@ import { Meeting } from 'src/entity/meeting.entity';
 import { MeetingMember } from 'src/entity/meetingMember.entity';
 import { Repository } from 'typeorm';
 import { MeetingDto } from './dto/meeting.dto';
+import { MeetingDate } from 'src/entity/meetingDate.entity';
+import { Member } from 'src/entity/member.entity';
+import { Timezone } from 'src/entity/timezone.entity';
+import { EntityNotFoundException } from 'src/common/exception/service.exception';
 
 @Injectable()
 export class MeetingsService {
@@ -12,6 +16,12 @@ export class MeetingsService {
     private meetings: Repository<Meeting>,
     @InjectRepository(MeetingMember)
     private meetingMembers: Repository<MeetingMember>,
+    @InjectRepository(MeetingDate)
+    private meetingDates: Repository<MeetingDate>,
+    @InjectRepository(Member)
+    private members: Repository<Member>,
+    @InjectRepository(Timezone)
+    private timezones: Repository<Timezone>,
   ) {}
 
   async getMeetings(): Promise<Meeting[]> {
@@ -39,8 +49,36 @@ export class MeetingsService {
     );
   }
 
-  createMeeting(): boolean {
-    return false;
+  async createMeeting(meetingDto: MeetingDto, managerId: number) {
+    const manager = await this.members.findOne({ where: { id: managerId } });
+    const timezone = await this.timezones.findOne({
+      where: { id: meetingDto.timezone_id },
+    });
+
+    if (!manager || !timezone)
+      throw EntityNotFoundException(
+        '미팅을 생성하기 위한 속성이 유효하지 않습니다.',
+      );
+
+    const meetingResult = await this.meetings.insert({
+      member_id: manager.id,
+      timezone_id: timezone.id,
+      name: meetingDto.name,
+      start_time: meetingDto.start_time,
+      end_time: meetingDto.end_time,
+    });
+
+    const meetingId = meetingResult.identifiers[0].id;
+
+    if (!meetingId)
+      throw EntityNotFoundException('미팅이 올바르게 생성되지 않았습니다.');
+
+    meetingDto.available_date.map(async (availableDate) => {
+      await this.meetingDates.insert({
+        meeting_id: meetingId,
+        available_date: availableDate,
+      });
+    });
   }
 
   getMeetingById(meetingId: number): Meeting {

--- a/src/meetings/meetings.service.ts
+++ b/src/meetings/meetings.service.ts
@@ -81,7 +81,17 @@ export class MeetingsService {
     });
   }
 
-  getMeetingById(meetingId: number): Meeting {
-    return;
+  async getMeetingById(meetingId: number) {
+    const meeting = await this.meetings.findOne({ where: { id: meetingId } });
+    const meetingDates = await this.meetingDates.find({
+      where: { id: meetingId },
+    });
+
+    if (!meeting || !meetingDates)
+      throw EntityNotFoundException('미팅을 찾을 수 없습니다');
+
+    meeting.meeting_dates = meetingDates;
+
+    return meeting;
   }
 }

--- a/src/meetings/meetings.service.ts
+++ b/src/meetings/meetings.service.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Meeting } from 'src/entity/meeting.entity';
 import { MeetingMember } from 'src/entity/meetingMember.entity';
 import { Repository } from 'typeorm';
+import { MeetingDto } from './dto/meeting.dto';
 
 @Injectable()
 export class MeetingsService {

--- a/src/meetings/meetings.service.ts
+++ b/src/meetings/meetings.service.ts
@@ -14,8 +14,14 @@ export class MeetingsService {
     return await this.meetings.find();
   }
 
-  deleteMeetingById(meetingId: number): boolean {
-    return false;
+  async deleteMeetingById(meetingId: number): Promise<any> {
+    const targetMeeting = await this.meetings.findOne({
+      where: { id: meetingId },
+    });
+    if (!targetMeeting)
+      throw new HttpException('Meeting Not Found', HttpStatus.NOT_FOUND);
+
+    await this.meetings.delete({ id: meetingId });
   }
 
   patchMeetingById(meetingId: number, listVisible: number): boolean {

--- a/src/meetings/meetings.service.ts
+++ b/src/meetings/meetings.service.ts
@@ -1,10 +1,13 @@
-import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
 import { Meeting } from 'src/entity/meeting.entity';
+import { Repository } from 'typeorm';
 
 @Injectable()
 export class MeetingsService {
-  getMeetings(): Meeting[] {
-    return [];
+  constructor(
+    @InjectRepository(Meeting)
+    private meetings: Repository<Meeting>,
+  ) {}
   }
 
   deleteMeetingById(meetingId: number): boolean {

--- a/src/meetings/meetings.service.ts
+++ b/src/meetings/meetings.service.ts
@@ -8,6 +8,7 @@ import { MeetingDate } from 'src/entity/meetingDate.entity';
 import { Member } from 'src/entity/member.entity';
 import { Timezone } from 'src/entity/timezone.entity';
 import { EntityNotFoundException } from 'src/common/exception/service.exception';
+import { AvailableDate } from './dto/availableDate.dto';
 
 @Injectable()
 export class MeetingsService {
@@ -61,9 +62,9 @@ export class MeetingsService {
       );
 
     const meetingResult = await this.meetings.insert({
+      name: meetingDto.name,
       member_id: manager.id,
       timezone_id: timezone.id,
-      name: meetingDto.name,
       start_time: meetingDto.start_time,
       end_time: meetingDto.end_time,
     });
@@ -73,12 +74,14 @@ export class MeetingsService {
     if (!meetingId)
       throw EntityNotFoundException('미팅이 올바르게 생성되지 않았습니다.');
 
-    meetingDto.available_date.map(async (availableDate) => {
+    meetingDto.available_dates.map(async (availableDate: AvailableDate) => {
       await this.meetingDates.insert({
         meeting_id: meetingId,
-        available_date: availableDate,
+        available_date: availableDate.date,
       });
     });
+
+    return meetingResult;
   }
 
   async getMeetingById(meetingId: number) {

--- a/src/meetings/meetings.service.ts
+++ b/src/meetings/meetings.service.ts
@@ -1,6 +1,7 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Meeting } from 'src/entity/meeting.entity';
+import { MeetingMember } from 'src/entity/meetingMember.entity';
 import { Repository } from 'typeorm';
 
 @Injectable()
@@ -8,13 +9,15 @@ export class MeetingsService {
   constructor(
     @InjectRepository(Meeting)
     private meetings: Repository<Meeting>,
+    @InjectRepository(MeetingMember)
+    private meetingMembers: Repository<MeetingMember>,
   ) {}
 
   async getMeetings(): Promise<Meeting[]> {
     return await this.meetings.find();
   }
 
-  async deleteMeetingById(meetingId: number): Promise<any> {
+  async deleteMeetingById(meetingId: number) {
     const targetMeeting = await this.meetings.findOne({
       where: { id: meetingId },
     });
@@ -24,8 +27,15 @@ export class MeetingsService {
     await this.meetings.delete({ id: meetingId });
   }
 
-  patchMeetingById(meetingId: number, listVisible: number): boolean {
-    return false;
+  async hideMeetingById(
+    memberId: number,
+    meetingId: number,
+    listVisible: number,
+  ) {
+    await this.meetingMembers.update(
+      { meeting_id: meetingId, member_id: memberId },
+      { list_visible: listVisible },
+    );
   }
 
   createMeeting(): boolean {

--- a/src/meetings/schedule/dto/schedule.dto.ts
+++ b/src/meetings/schedule/dto/schedule.dto.ts
@@ -1,6 +1,6 @@
 import { MeetingDate } from "src/entity/meetingDate.entity";
 
-export class Schedule {
+export class ScheduleDto {
     nickname: string;
     selected_items: MeetingDate[]
 }

--- a/src/meetings/schedule/meetings.schedule.controller.ts
+++ b/src/meetings/schedule/meetings.schedule.controller.ts
@@ -1,6 +1,6 @@
 import { Body, Controller, Get, Param, Post, Put } from '@nestjs/common';
 import { MeetingsScheduleService } from './meetings.schedule.service';
-import { Schedule } from 'src/meetings/schedule/dto/schedule.dto';
+import { ScheduleDto } from 'src/meetings/schedule/dto/schedule.dto';
 @Controller('meetings/:id/schedule')
 export class MeetingsScheduleController {
   constructor(
@@ -21,7 +21,7 @@ export class MeetingsScheduleController {
   @Put()
   updateSchedules(
     @Param('id') meetingId: number,
-    @Body() newSchedule: Schedule,
+    @Body() newSchedule: ScheduleDto,
   ) {
     const success = this.MeetingsScheduleService.updateSchedules(
       meetingId,

--- a/src/meetings/schedule/meetings.schedule.service.ts
+++ b/src/meetings/schedule/meetings.schedule.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Schedule } from 'src/meetings/schedule/dto/schedule.dto';
+import { ScheduleDto } from 'src/meetings/schedule/dto/schedule.dto';
 
 @Injectable()
 export class MeetingsScheduleService {
@@ -7,15 +7,15 @@ export class MeetingsScheduleService {
     return false;
   }
 
-  getPersonalSchedules(meetingId: number): Schedule {
+  getPersonalSchedules(meetingId: number): ScheduleDto {
     return;
   }
 
-  updateSchedules(meetingId: number, newSchedule: Schedule): boolean {
+  updateSchedules(meetingId: number, newSchedule: ScheduleDto): boolean {
     return false;
   }
 
-  getAllSchedules(meetingId: number): Schedule[] {
+  getAllSchedules(meetingId: number): ScheduleDto[] {
     return [];
   }
 }


### PR DESCRIPTION
- closes #6 
- `meetings` 모듈과 관련된 api를 구현하였습니다.
- [노션 api docs](https://www.notion.so/API-DOCS-07eccb111b5a4955a85c234e2d665272?p=7efb445f90414c29be59f8525d5821be&pm=s)의 3~7번 api에 해당합니다.

- 현재 member 추가와 timezone 관련 api가 구현이 안되어 있어서 임의로 db에 추가할 수 있는 api를 테스트용으로 같이 끼워넣었습니다. @ch4n33 나중에 작업 완료되시면 삭제해주세요:)